### PR TITLE
Add support for Tradeshift npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,17 @@
 version: 2
+registries:
+  npm-tradeshift:
+    type: npm-registry
+    url: 'https://npm.pkg.github.com'
+    token: ${{secrets.NPM_READ_TOKEN}}
+
 updates:
   # Enable version updates for npm
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
+    registries:
+      - npm-tradeshift
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'


### PR DESCRIPTION
Dependabot didn't support private npm repositories however it currently does! I have added a token for dependabot to use but there needs to be a change to .dependabot.yaml for this to work