### PR TITLE
fix: auto-update github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       prefix: 'fix'
       prefix-development: 'build'
       include: 'scope'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'build'
+      include: 'scope'


### PR DESCRIPTION
Motivation: We want to get PR's when actions are outdated