### PR TITLE
chore: change of ownership from developer-productivity to partner-enablement-and-apps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tradeshift/developer-productivity @Tradeshift/ci-workers
+* @Tradeshift/partner-enablement-and-apps @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -1,7 +1,7 @@
 {
     "description": "GHA for building and publishing Tradeshift docs",
     "maintainers": [
-        "developer-productivity"
+        "partner-enablement-and-apps"
     ],
     "topics": [
         "github-action",

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -11,5 +11,5 @@ metadata:
     - nodejs
 spec:
   type: library
-  owner: developer-productivity
+  owner: partner-enablement-and-apps
   lifecycle: production


### PR DESCRIPTION
This PR changes the ownership of this repo to partner-enablement-and-apps, as the developer productivity team doesn't exist anymore.